### PR TITLE
Support Anonymous Zaps

### DIFF
--- a/frontend/src/Components/ZapButton.elm
+++ b/frontend/src/Components/ZapButton.elm
@@ -34,7 +34,7 @@ import Nostr.Event exposing (Kind(..), TagReference(..))
 import Nostr.Nip19 as Nip19 exposing (NIP19Type(..))
 import Nostr.Relay exposing (websocketUrl)
 import Nostr.Send exposing (SendRequest(..))
-import Nostr.Types exposing (LoginStatus, PubKey, RelayUrl, loggedInPubKey)
+import Nostr.Types exposing (LoginStatus(..), PubKey, RelayUrl, loggedInPubKey)
 import Set exposing (Set)
 import Ui.Shared exposing (emptyHtml)
 import Ui.Styles
@@ -221,6 +221,14 @@ view (Settings settings) =
                 |> Maybe.map (\instanceId -> "-" ++ instanceId)
                 |> Maybe.withDefault ""
 
+        anonAttr =
+            case settings.loginStatus of
+                LoggedIn _ _ ->
+                    []
+
+                _ ->
+                    [ ( "data-anon", "true" ) ]
+
         ( nostrZapAttributes, zapComponent ) =
             Maybe.map2
                 (\npub _ ->
@@ -234,6 +242,7 @@ view (Settings settings) =
                       , ( "data-button-color", "#334155" )
                       ]
                         ++ nip19TargetAttr
+                        ++ anonAttr
                     , Html.node "js-zap-component"
                         [ Attr.property "buttonId" (Encode.string buttonId) ]
                         []

--- a/frontend/src/Ui/Interactions.elm
+++ b/frontend/src/Ui/Interactions.elm
@@ -14,7 +14,7 @@ import Json.Encode as Encode
 import Nostr
 import Nostr.Nip19 as Nip19 exposing (NIP19Type(..))
 import Nostr.Relay exposing (websocketUrl)
-import Nostr.Types exposing (LoginStatus, PubKey, loggedInPubKey)
+import Nostr.Types exposing (LoginStatus(..), PubKey, loggedInPubKey)
 import Set exposing (Set)
 import Tailwind.Utilities as Tw
 import Ui.Shared exposing (emptyHtml)
@@ -85,7 +85,7 @@ viewReactions icon maybeMsg maybeCount previewData instanceId =
             ]
         ]
         [ if icon == Icon.FeatherIcon FeatherIcons.zap then
-            zapButton (previewData.loginStatus |> loggedInPubKey) previewData.maybeNip19Target previewData.zapRelays instanceId
+            zapButton (previewData.loginStatus |> loggedInPubKey) previewData.maybeNip19Target previewData.zapRelays instanceId previewData.loginStatus
 
           else
             div
@@ -113,8 +113,8 @@ formatZapNum browserEnv milliSats =
     browserEnv.formatNumber "0 a" <| toFloat (milliSats // 1000)
 
 
-zapButton : Maybe PubKey -> Maybe String -> Set String -> String -> Html msg
-zapButton maybePubKey maybeNip19Target zapRelays instanceId =
+zapButton : Maybe PubKey -> Maybe String -> Set String -> String -> LoginStatus -> Html msg
+zapButton maybePubKey maybeNip19Target zapRelays instanceId loginStatus =
     let
         maybeNip19TargetAttr =
             maybeNip19Target
@@ -131,6 +131,14 @@ zapButton maybePubKey maybeNip19Target zapRelays instanceId =
             maybePubKey
                 |> Maybe.andThen (\pubKey -> Nip19.encode (Npub pubKey) |> Result.toMaybe)
 
+        anonAttr =
+            case loginStatus of
+                LoggedIn _ _ ->
+                    []
+
+                _ ->
+                    [ Attr.attribute "data-anon" "true" ]
+
         ( nostrZapAttributes, zapComponent ) =
             maybeNpub
                 |> Maybe.map
@@ -141,6 +149,7 @@ zapButton maybePubKey maybeNip19Target zapRelays instanceId =
                           , Attr.attribute "data-button-color" "#334155"
                           ]
                             ++ Maybe.withDefault [] maybeNip19TargetAttr
+                            ++ anonAttr
                         , Html.node "js-zap-component"
                             [ Attr.property "buttonId" (Encode.string ("zap-button-" ++ instanceId)) ]
                             []

--- a/frontend/src/Ui/Profile.elm
+++ b/frontend/src/Ui/Profile.elm
@@ -163,7 +163,7 @@ viewAuthorCard profile profileViewData =
                     [ text (profileDisplayName profile.pubKey profile) ]
                 ]
             , linkElementWrapper [ viewNip05 styles profile ]
-            , viewLNAddress styles profile zapRelays
+            , viewLNAddress styles profile zapRelays profileViewData.loginStatus
             ]
         , followBookmarkElement profile.pubKey profileViewData.following
         ]
@@ -270,7 +270,7 @@ viewProfile profile profileViewData =
                     [ text (profile.about |> Maybe.withDefault "") ]
                 , viewWebsite styles profile
                 , viewNip05 styles profile
-                , viewLNAddress styles profile zapRelays
+                , viewLNAddress styles profile zapRelays profileViewData.loginStatus
                 , viewNpub profileViewData.theme profile
                 ]
             , div
@@ -369,14 +369,14 @@ viewNip05 styles profile =
             emptyHtml
 
 
-viewLNAddress : Styles msg -> Profile -> Set String -> Html msg
-viewLNAddress styles profile zapRelays =
+viewLNAddress : Styles msg -> Profile -> Set String -> LoginStatus -> Html msg
+viewLNAddress styles profile zapRelays loginStatus =
     profile.lud16
         |> Maybe.map
             (\lud16 ->
                 p
                     (styles.colorStyleGrayscaleText ++ styles.textStyleBody ++ [ css [ Tw.flex, Tw.items_center, Tw.overflow_hidden, Tw.text_ellipsis ] ])
-                    [ zapButton (Just profile.pubKey) Nothing zapRelays "0"
+                    [ zapButton (Just profile.pubKey) Nothing zapRelays "0" loginStatus
                     , text <| lud16
                     ]
             )


### PR DESCRIPTION
Avoid requesting the user to login on zaps by setting the data-anon attribute to true.